### PR TITLE
Add ability to preselect a type in the DocExplorer

### DIFF
--- a/src/components/DocExplorer.js
+++ b/src/components/DocExplorer.js
@@ -39,11 +39,23 @@ const initialNav = {
 export class DocExplorer extends React.Component {
   static propTypes = {
     schema: PropTypes.instanceOf(GraphQLSchema),
+    defaultTypeOrField: PropTypes.string,
   };
 
-  constructor() {
-    super();
-    this.state = { navStack: [initialNav] };
+  constructor(props) {
+    super(props);
+
+    this.state = { navStack: this.createFreshNavStack(props) };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.schema !== nextProps.schema) {
+      if (nextProps.schema) {
+        this.setState({
+          navStack: this.createFreshNavStack(nextProps),
+        });
+      }
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -137,6 +149,22 @@ export class DocExplorer extends React.Component {
         </div>
       </div>
     );
+  }
+
+  createFreshNavStack(props) {
+    const navStack = [initialNav];
+
+    if (props.defaultTypeOrField && props.schema !== undefined) {
+      const typeOrField = props.schema.getType(props.defaultTypeOrField);
+      if (typeOrField) {
+        navStack.push({
+          name: typeOrField.name,
+          def: typeOrField,
+        });
+      }
+    }
+
+    return navStack;
   }
 
   // Public API

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -63,6 +63,8 @@ export class GraphiQL extends React.Component {
     editorTheme: PropTypes.string,
     onToggleHistory: PropTypes.func,
     ResultsTooltip: PropTypes.any,
+
+    defaultTypeOrField: PropTypes.string,
   };
 
   constructor(props) {
@@ -407,7 +409,8 @@ export class GraphiQL extends React.Component {
             ref={c => {
               this.docExplorerComponent = c;
             }}
-            schema={this.state.schema}>
+            schema={this.state.schema}
+            defaultTypeOrField={this.props.defaultTypeOrField}>
             <div className="docExplorerHide" onClick={this.handleToggleDocs} />
           </DocExplorer>
         </div>


### PR DESCRIPTION
This is achieved via a new `defaultTypeOrField: string` prop that
the DocExplorer adds to the schema nav item whenever it needs to
create a fresh nav stack.